### PR TITLE
Fix container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY pyproject.toml poetry.lock* /app/
 
 # Install dependencies without creating a virtual environment (use the system Python environment)
 RUN poetry config virtualenvs.create false \
-    && poetry install --no-interaction --no-ansi
+    && poetry install --no-root --no-interaction --no-ansi
 
 # Copy the rest of the application files
 COPY . /app


### PR DESCRIPTION
Docker image could not build without this.

We will have a build workflow in GH CI very soon 🙏 

```
 => ERROR [6/7] RUN poetry config virtualenvs.create false     && poetry install --no-interaction --no-ansi                     2.6s
------
 > [6/7] RUN poetry config virtualenvs.create false     && poetry install --no-interaction --no-ansi:
0.894 Skipping virtualenv creation, as specified in config file.
0.973 Installing dependencies from lock file
1.028
1.028 Package operations: 8 installs, 3 updates, 0 removals
1.028
1.028   - Downgrading certifi (2025.4.26 -> 2024.8.30)
1.029   - Downgrading charset-normalizer (3.4.2 -> 3.4.0)
1.030   - Downgrading urllib3 (2.4.0 -> 2.2.3)
1.803   - Installing backoff (2.2.1)
1.804   - Installing iniconfig (2.1.0)
1.804   - Installing pluggy (1.6.0)
1.805   - Installing unidecode (1.3.8)
2.061   - Installing kinto-http (11.8.0)
2.062   - Installing pytest (8.3.5)
2.062   - Installing ruff (0.11.11)
2.063   - Installing types-requests (2.32.0.20250602)
2.482
2.482 Installing the current project: fxrelay-allowlist-updater (0.1.0)
2.483
2.483 Error: The current project could not be installed: No file/folder found for package fxrelay-allowlist-updater
2.483 If you do not want to install the current project use --no-root.
2.483 If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
2.483 If you did intend to install the current project, you may need to set `packages` in your pyproject.toml file.
2.483
------
Dockerfile:21
--------------------
  20 |     # Install dependencies without creating a virtual environment (use the system Python environment)
  21 | >>> RUN poetry config virtualenvs.create false \
  22 | >>>     && poetry install --no-interaction --no-ansi
  23 |
--------------------
ERROR: failed to solve: process "/bin/sh -c poetry config virtualenvs.create false     && poetry install --no-interaction --no-ansi" did not complete successfully: exit code: 1

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/wrzkesobxud46aknl62ysdvea
```