### PR TITLE
MPP-4131 - feat(script): add blocklist in addition to allowlist

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,9 +52,10 @@ jobs:
             --network=host \
             --env KINTO_INI=config/testing.ini \
             mozilla/remote-settings
-      - name: Create collection
+      - name: Create collections
         run: |
           curl -X PUT "${SERVER}/buckets/main-workspace/collections/fxrelay-allowlist"
+          curl -X PUT "${SERVER}/buckets/main-workspace/collections/fxrelay-denylist"
 
       - name: Run job from container
         run: |

--- a/script.py
+++ b/script.py
@@ -30,53 +30,32 @@ if ENVIRONMENT not in {"local", "dev", "stage", "prod"}:
 
 # Constants for collection
 BUCKET = "main-workspace"
-COLLECTION = "fxrelay-allowlist"
+ALLOWLIST_COLLECTION = "fxrelay-allowlist"
+BLOCKLIST_COLLECTION = "fxrelay-denylist"
+LIST_INPUT_URL_BASE = (
+    "https://raw.githubusercontent.com/mozilla/fx-private-relay/refs/heads/main/privaterelay"
+)
 ALLOWLIST_INPUT_URL = os.getenv(
     "ALLOWLIST_INPUT_URL",
-    "https://raw.githubusercontent.com/mozilla/fx-private-relay/refs/heads/main/privaterelay/fxrelay-allowlist-domains.txt",
+    f"{LIST_INPUT_URL_BASE}/fxrelay-allowlist-domains.txt",
+)
+BLOCKLIST_INPUT_URL = os.getenv(
+    "BLOCKLIST_INPUT_URL",
+    f"{LIST_INPUT_URL_BASE}/fxrelay-blocklist-domains.txt",
 )
 
 
-def fetch_allowlist():
-    print(f"📥 Loading new allowlist from {ALLOWLIST_INPUT_URL}")
-    response = requests.get(ALLOWLIST_INPUT_URL, timeout=REQUEST_TIMEOUT_SECONDS)
+def fetch_list(input_url):
+    print(f"📥 Loading list from {input_url}")
+    response = requests.get(input_url, timeout=REQUEST_TIMEOUT_SECONDS)
     response.raise_for_status()
-    new_allowlist = response.content.decode()
-    domains = set(filter(None, new_allowlist.split("\n")))
+    new_list = response.content.decode()
+    domains = set(filter(None, new_list.split("\n")))
     print(f"📋 Parsed {len(domains)} domains.")
     return [{"id": domain.replace(".", "-"), "domain": domain} for domain in sorted(domains)]
 
 
-def main():
-    if SENTRY_DSN:
-        # Initialize Sentry for error reporting.
-        sentry_sdk.init(SENTRY_DSN, integrations=[GcpIntegration()], environment=SENTRY_ENV)
-    else:
-        print("⚠️ Sentry is not configured. Set SENTRY_DSN environment variable to enable it.")
-
-    client = Client(
-        server_url=SERVER,
-        auth=AUTHORIZATION,
-        bucket=BUCKET,
-        collection=COLLECTION,
-        dry_mode=IS_DRY_RUN,
-    )
-
-    try:
-        print("🔐 Checking credentials...", end="")
-        server_info = client.server_info()
-        print("✅")
-        if "user" in server_info:
-            print(f"👤 Logged in as {server_info['user']['id']}")
-        else:
-            print("⚠️ Anonymous access")
-    except Exception as e:
-        print(f"❌ Failed to connect to Remote Settings server: {e}")
-        return 1
-
-    print("📥 Fetching new allowlist records...")
-    source_records = fetch_allowlist()
-
+def sync_collection(client, source_records):
     print("📥 Fetching current destination records...")
     try:
         dest_records = client.get_records()
@@ -123,6 +102,53 @@ def main():
     except KintoException as e:
         print(f"❌ Failed to update collection status: {e}")
         return 1
+
+    return 0
+
+
+def main():
+    if SENTRY_DSN:
+        # Initialize Sentry for error reporting.
+        sentry_sdk.init(SENTRY_DSN, integrations=[GcpIntegration()], environment=SENTRY_ENV)
+    else:
+        print("⚠️ Sentry is not configured. Set SENTRY_DSN environment variable to enable it.")
+
+    # --- Allowlist ---
+    allowlist_client = Client(
+        server_url=SERVER,
+        auth=AUTHORIZATION,
+        bucket=BUCKET,
+        collection=ALLOWLIST_COLLECTION,
+        dry_mode=IS_DRY_RUN,
+    )
+    try:
+        print("🔐 Checking credentials...", end="")
+        server_info = allowlist_client.server_info()
+        print("✅")
+        if "user" in server_info:
+            print(f"👤 Logged in as {server_info['user']['id']}")
+        else:
+            print("⚠️ Anonymous access")
+    except Exception as e:
+        print(f"❌ Failed to connect to Remote Settings server: {e}")
+        return 1
+
+    print("\n=== Processing ALLOWLIST ===")
+    print("📥 Fetching new allowlist records...")
+    allowlist_records = fetch_list(ALLOWLIST_INPUT_URL)
+    result = sync_collection(allowlist_client, allowlist_records)
+    if result != 0:
+        return result
+
+    # --- Blocklist ---
+    print("\n=== Processing BLOCKLIST ===")
+    blocklist_client = allowlist_client.clone(collection=BLOCKLIST_COLLECTION)
+
+    print("📥 Fetching new blocklist records...")
+    blocklist_records = fetch_list(BLOCKLIST_INPUT_URL)
+    result = sync_collection(blocklist_client, blocklist_records)
+    if result != 0:
+        return result
 
     return 0
 

--- a/test.py
+++ b/test.py
@@ -6,10 +6,20 @@ from script import main
 
 
 @pytest.fixture
-def mocked_client():
-    # Mock the kinto_http.Client where it is imported.
+def mocked_clients():
     with mock.patch("script.Client", spec=True) as mocked_class:
-        yield mocked_class()
+        allow_client = mock.MagicMock(name="allow_client")
+        block_client = mock.MagicMock(name="block_client")
+        allow_batch = mock.MagicMock(name="allow_batch")
+        block_batch = mock.MagicMock(name="block_batch")
+        allow_client.batch.return_value.__enter__.return_value = allow_batch
+        allow_client.batch.return_value.__exit__.return_value = None
+        block_client.batch.return_value.__enter__.return_value = block_batch
+        block_client.batch.return_value.__exit__.return_value = None
+        allow_client.clone.return_value = block_client
+        mocked_class.side_effect = [allow_client]
+
+        yield (allow_client, block_client, allow_batch, block_batch)
 
 
 @pytest.fixture
@@ -18,52 +28,81 @@ def mocked_get():
         yield mock_get
 
 
-def test_cannot_call_unknown_method(mocked_client):
-    with pytest.raises(AttributeError):
-        mocked_client.unknown_method()
+def setup_env(monkeypatch):
+    # Ensure environment variables are set for both lists
+    monkeypatch.setenv("ALLOWLIST_INPUT_URL", "https://example.com/allowlist.txt")
+    monkeypatch.setenv("BLOCKLIST_INPUT_URL", "https://example.com/blocklist.txt")
 
 
-def test_sync_allowlist_success(mocked_client, mocked_get, capsys):
-    mocked_client.server_info.return_value = {}
-    mocked_client.get_records.return_value = [
-        {"id": "old-com", "domain": "old.com"},
+def test_sync_both_lists_success(mocked_clients, mocked_get, monkeypatch):
+    setup_env(monkeypatch)
+    allow_client, block_client, allow_batch, block_batch = mocked_clients
+    allow_client.server_info.return_value = {}
+    allow_client.get_records.return_value = [{"id": "old-allow-com", "domain": "old-allow.com"}]
+    block_client.get_records.return_value = [{"id": "old-block-com", "domain": "old-block.com"}]
+    mocked_get.side_effect = [
+        mock.Mock(ok=True, content=b"new-allow.com\n"),
+        mock.Mock(ok=True, content=b"new-block.com\n"),
     ]
-    mocked_get.return_value.ok = True
-    mocked_get.return_value.content = b"new.com\n"
-    # Get a handle on the context manager from ``client.batch()``:
-    batch_client = mocked_client.batch().__enter__()
-    batch_client.results.return_value = [{"id": "old-com"}, {"id": "new.com"}]
 
-    main()
+    rc = main()
 
-    assert "✅ Batch 2 operations applied." in capsys.readouterr().out
-    batch_client.delete_record.assert_called_once_with(id="old-com")
-    batch_client.create_record.assert_called_once_with(data={"id": "new-com", "domain": "new.com"})
-    mocked_client.request_review.assert_called_once_with(message="r?")
+    assert rc == 0
+    # Review requested for both
+    assert allow_client.server_info.call_count == 1
+    assert allow_client.get_records.call_count == 1
+    assert allow_batch.create_record.call_args_list[0].kwargs["data"]["domain"] == "new-allow.com"
+    assert allow_batch.delete_record.call_count == 1
+    assert allow_batch.delete_record.call_args_list[0].kwargs["id"] == "old-allow-com"
+    assert block_batch.create_record.call_count == 1
+    assert block_batch.create_record.call_args_list[0].kwargs["data"]["domain"] == "new-block.com"
+    assert block_batch.delete_record.call_count == 1
+    assert block_batch.delete_record.call_args_list[0].kwargs["id"] == "old-block-com"
+    assert allow_client.request_review.call_count == 1
+    assert block_client.request_review.call_count == 1
 
 
-def test_no_changes_found(mocked_client, mocked_get):
-    mocked_client.server_info.return_value = {}
-    mocked_client.get_records.return_value = [
-        {"id": "nochanges-com", "domain": "nochanges.com"},
+def test_no_changes_for_both_lists(mocked_clients, mocked_get, monkeypatch):
+    setup_env(monkeypatch)
+    allow_client, block_client, allow_batch, block_batch = mocked_clients
+    allow_client.server_info.return_value = {}
+    allow_client.get_records.return_value = [
+        {"id": "nochange-allow-com", "domain": "nochange-allow.com"}
     ]
-    mocked_get.return_value.ok = True
-    mocked_get.return_value.content = b"nochanges.com\n"
+    block_client.get_records.return_value = [
+        {"id": "nochange-block-com", "domain": "nochange-block.com"}
+    ]
+    mocked_get.side_effect = [
+        mock.Mock(ok=True, content=b"nochange-allow.com\n"),
+        mock.Mock(ok=True, content=b"nochange-block.com\n"),
+    ]
+    allow_client.server_info.return_value = {}
 
-    main()
+    rc = main()
 
-    mocked_client.get_records.assert_called_once()
-    mocked_get.assert_called_once()
-    mocked_client.batch.assert_not_called()
+    assert rc == 0
+    # Should not call batch for either collection
+    assert allow_batch.call_count == 0
+    assert block_batch.call_count == 0
 
 
-def test_server_connection_failure(mocked_client, mocked_get, capsys):
-    mocked_get.return_value.ok = True
-    mocked_get.return_value.content = b"domain.com\n"
+def test_allowlist_connection_failure_only(mocked_clients, mocked_get, monkeypatch):
+    """
+    Allowlist fails on server_info (early exit, no batch ops; blocklist is not exercised).
+    """
+    setup_env(monkeypatch)
+    allow_client, _, _, _ = mocked_clients
 
-    mocked_client.server_info.side_effect = Exception("Connection error")
+    # Provide deterministic list fetches (won't be used due to early exit).
+    mocked_get.side_effect = [
+        mock.Mock(ok=True, content=b"allow.com\n"),
+        mock.Mock(ok=True, content=b"block.com\n"),
+    ]
 
-    main()
+    # Fail as early as possible during allowlist server connectivity check.
+    allow_client.server_info.side_effect = Exception("Allowlist connection error")
 
-    captured = capsys.readouterr()
-    assert "❌ Failed to connect to Remote Settings server: Connection error" in captured.out
+    rc = main()
+
+    assert allow_client.server_info.call_count == 1
+    assert rc == 1


### PR DESCRIPTION
To keep both domain lists up-to-date in a single run, refactored to update both allowlist and blocklist collections from corresponding source files in the fx-private-relay repository.